### PR TITLE
implement JWT authentication for loan creation

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -60,3 +60,7 @@ resilience4j:
         slidingWindowSize: 10
         minimumNumberOfCalls: 10
         waitDurationInOpenState: "10s"
+
+springdoc:
+  swagger-ui:
+    path: "/swagger-ui"

--- a/domain/model/src/main/java/co/com/pragma/model/user/gateways/UserGateway.java
+++ b/domain/model/src/main/java/co/com/pragma/model/user/gateways/UserGateway.java
@@ -3,5 +3,5 @@ package co.com.pragma.model.user.gateways;
 import reactor.core.publisher.Mono;
 
 public interface UserGateway {
-	Mono<Boolean> userExists(String identification, String email);
+	Mono<Boolean> userExists(String token);
 }

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/createloan/CreateLoanUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/createloan/CreateLoanUseCase.java
@@ -24,7 +24,7 @@ public class CreateLoanUseCase implements ICreateLoanUseCase {
     private final UserGateway userGateway;
     
     @Override
-    public Mono<Loan> execute(Loan loan) {
+    public Mono<Loan> execute(Loan loan, String token) {
         
         ///  Validate if exists loan type
         Mono<LoanType> loanTypeExists = loanTypeRepository.findById(loan.getType().getId())
@@ -35,7 +35,7 @@ public class CreateLoanUseCase implements ICreateLoanUseCase {
             .switchIfEmpty(Mono.error(new LoanStatusNotExists(LoanStatusConstants.PENDING)));
         
         ///  validate if user exists
-        Mono<Boolean> userExists = userGateway.userExists(loan.getEmail(), loan.getIdentificationNumber())
+        Mono<Boolean> userExists = userGateway.userExists(token)
             .filter(exist -> exist)
             .switchIfEmpty(Mono.error(new UserDoesntExistsException(loan.getEmail(), loan.getIdentificationNumber())));
         

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/createloan/ICreateLoanUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/createloan/ICreateLoanUseCase.java
@@ -4,5 +4,5 @@ import co.com.pragma.model.loan.Loan;
 import reactor.core.publisher.Mono;
 
 public interface ICreateLoanUseCase {
-    Mono<Loan> execute(Loan loan);
+    Mono<Loan> execute(Loan loan, String token);
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/consumer/RestConsumer.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/consumer/RestConsumer.java
@@ -1,11 +1,11 @@
 package co.com.pragma.consumer;
 
-import co.com.pragma.consumer.api.model.request.UserExistsRequest;
 import co.com.pragma.consumer.api.model.response.UserExistsResponse;
 import co.com.pragma.consumer.constants.ExternalApiConstants;
 import co.com.pragma.model.user.gateways.UserGateway;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -18,16 +18,10 @@ public class RestConsumer implements UserGateway {
     
     @Override
     @CircuitBreaker(name = "checkUserExists")
-    public Mono<Boolean> userExists(String email, String identificationNumber) {
-        return client.post()
-            .uri(
-                uriBuilder -> uriBuilder
-                    .path(ExternalApiConstants.USER_EXISTS)
-                    .build()
-            )
-            .bodyValue(
-               new UserExistsRequest(email, identificationNumber)
-            )
+    public Mono<Boolean> userExists(String token) {
+        return client.get()
+            .uri(uriBuilder -> uriBuilder.path(ExternalApiConstants.USER_EXISTS).build())
+            .headers(headers -> headers.set(HttpHeaders.AUTHORIZATION, token))
             .retrieve()
             .bodyToMono(UserExistsResponse.class)
             .map(UserExistsResponse::exists);

--- a/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/consumer/RestConsumerTest.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/consumer/RestConsumerTest.java
@@ -11,8 +11,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.test.StepVerifier;
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static reactor.test.StepVerifier.create;
 
 
 class RestConsumerTest {
@@ -43,9 +48,9 @@ class RestConsumerTest {
             .setResponseCode(HttpStatus.OK.value())
             .setBody("{\"exists\": true}"));
         
-        var response = restConsumer.userExists("test@email.com", "123456");
+        var response = restConsumer.userExists("Bearer some_token");
         
-        StepVerifier.create(response)
+        create(response)
             .expectNext(true)
             .verifyComplete();
     }
@@ -58,10 +63,31 @@ class RestConsumerTest {
             .setResponseCode(HttpStatus.OK.value())
             .setBody("{\"exists\": false}"));
         
-        var response = restConsumer.userExists("notfound@email.com", "0000");
+        var response = restConsumer.userExists("Bearer some_token");
         
-        StepVerifier.create(response)
+        create(response)
             .expectNext(false)
             .verifyComplete();
     }
+    
+    @Test
+    @DisplayName("Should return false when doesn't have role privileges")
+    void shouldReturnFalseWhenDoesNotHaveRolePrivileges() {
+        MockResponse response = new MockResponse()
+            .setResponseCode(401);
+        
+        mockBackEnd.enqueue(response);
+        
+        var result = restConsumer.userExists("invalid_token");
+        
+        create(result)
+            .expectErrorSatisfies(throwable -> {
+				assertInstanceOf(WebClientResponseException.class, throwable, "La excepción debe ser de tipo WebClientResponseException");
+                WebClientResponseException ex = (WebClientResponseException) throwable;
+                assertTrue(ex.getStatusCode().is4xxClientError(), "El código de estado debe ser de cliente (4xx)");
+            })
+            .verify();
+    }
+    
+    
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/SwaggerConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/SwaggerConfig.java
@@ -1,8 +1,11 @@
 package co.com.pragma.api.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -12,6 +15,8 @@ import org.springframework.context.annotation.Configuration;
             version = "1.0.0",
             description = "Microservicio para manejo de solicitudes de prestamos",
             contact = @Contact(name = "Andres Camperos")
-      )
+      ),
+    security = @SecurityRequirement(name = "bearerAuth")
 )
+@SecurityScheme(name = "bearerAuth", scheme = "bearer", type = SecuritySchemeType.HTTP, description = "JWT Bearer authentication", bearerFormat = "JWT")
 public class SwaggerConfig {}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/enums/ErrorCodes.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/enums/ErrorCodes.java
@@ -1,6 +1,7 @@
 package co.com.pragma.api.enums;
 
 import co.com.pragma.api.exceptions.JakartaValidationException;
+import co.com.pragma.api.exceptions.UserNotAuthenticatedException;
 import co.com.pragma.model.loan.exceptions.LoanAmountOutRangeException;
 import co.com.pragma.model.user.exceptions.UserDoesntExistsException;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCodes {
     INVALID_FIELD("400_INVALID_FIELD", HttpStatus.BAD_REQUEST, JakartaValidationException.class),
     USER_NOT_FOUND("404_USER_NOT_FOUND", HttpStatus.NOT_FOUND, UserDoesntExistsException.class),
+    USER_NOT_AUTHENTICATED("404_NOT_AUTHENTICATED", HttpStatus.UNAUTHORIZED, UserNotAuthenticatedException.class),
     LOAN_AMOUNT_OUT_RANGE("400_AMOUNT_OUT_RANGE", HttpStatus.BAD_REQUEST, LoanAmountOutRangeException.class),
     INTERNAL_SERVER_ERROR("500_INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, RuntimeException.class);
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/exceptions/UserNotAuthenticatedException.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/exceptions/UserNotAuthenticatedException.java
@@ -1,0 +1,7 @@
+package co.com.pragma.api.exceptions;
+
+public class UserNotAuthenticatedException extends RuntimeException {
+	public UserNotAuthenticatedException(String email) {
+		super("User with" + email + " is not authenticated");
+	}
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/handlers/LoanHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/handlers/LoanHandler.java
@@ -6,6 +6,7 @@ import co.com.pragma.api.mapper.LoanMapper;
 import co.com.pragma.usecase.createloan.CreateLoanUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -23,11 +24,13 @@ public class LoanHandler {
     private final LoanMapper loanMapper;
     
     public Mono<ServerResponse> listenPOSTCreateLoan(ServerRequest request) {
+        String authHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
+        
         return request.bodyToMono(CreateLoanRequest.class)
             .doOnNext(req -> log.info("Incoming loan creation request: {}", req))
             .flatMap(jakartaValidator::validate)
             .map(loanMapper::toDomain)
-            .flatMap(createLoanUseCase::execute)
+            .flatMap(req -> createLoanUseCase.execute(req, authHeader))
             .map(loanMapper::toDto)
             .doOnSuccess(dto -> log.info("Loan created successfully: {}", dto))
             .doOnError(error -> log.error("Error creating loan: {}", error.getMessage()))


### PR DESCRIPTION
## 🔀 Pull Request: Feature – Authentication with JWT

### 📌 Description

This PR adds authentication to the system using the Autenticación microservice with Spring WebFlux.
It follows hexagonal architecture principles, separating domain logic from infrastructure, and implements JWT token generation for secure session management.

The endpoint exposed is:

```
POST /api/v1/login
```

## ✅ Acceptance Criteria

* Domain-driven design & hexagonal architecture
  * Core authentication logic placed in the domain module.
  * Infrastructure handles persistence, adapters, and HTTP handlers.

* Authentication & Authorization
  * Login is performed using email and password.
  * JWT token is generated upon successful authentication.
  * Unlimited login attempts (no account lockout).
  * Each logged-in user can only access features according to their role:
  * `Administrador` / `Asesor`: Can register users.
  * `Cliente`: Can create loan requests, but only for themselves.

* Validation rules
  * User must exist and password must be correct.
  * Authentication is validated for protected endpoints:
    * Register user → requires Administrador or Asesor role.
    * Create loan request → requires Cliente role and can only submit on their own behalf.

* Logging
  * Trace logs added to monitor login attempts and token generation.

* Error handling
  * All exceptions are caught and mapped to controlled API error responses.
  * No internal stack traces or unexpected messages are exposed to clients.

* Limitations
  * Password recovery is not included in this version.

